### PR TITLE
Switch to using surrogate-control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
-# HTTP and server side cache integration for Grape and Rails [![Gem Version](https://badge.fury.io/rb/grape-rails-cache.png)](http://badge.fury.io/rb/grape-rails-cache)
+# Grape Surrogate Cache
 
-## Features
+A gem for easily caching responses using the [Surrogate-Control cache header](https://www.w3.org/TR/edge-arch/) with [Grape](https://github.com/ruby-grape/grape) and [Rails](https://github.com/rails/rails).
 
-- HTTP Headers cache, ETag, Cache-Control, If-None-Match
-- Server side cache for response body
-
+Based on [Grape Rails Cache](https://github.com/monterail/grape-rails-cache).
 
 ## Installation
 
 Add this line to your rails application's Gemfile:
 
 ```ruby
-gem 'grape-rails-cache'
+gem 'grape-rails-cache', github: "unsplash/grape-rails-cache"
 ```
 
 And then execute:
@@ -32,18 +30,10 @@ module MyApi < Grape::API
     desc "Return a post"
     get ":id" do
       post = Post.find(params[:id])
-      cache(key: "api:posts:#{post.id}", etag: post.updated_at, expires_in: 2.hours) do
+      cache(key: "api:posts:#{post.id}", expires_in: 2.hours, stale_for: 24.hours) do
         post # post.extend(PostRepresenter) etc, any code that renders response
       end
     end
   end
 end
 ```
-
-## Contributing
-
-1. Fork it
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request

--- a/lib/grape/rails/cache.rb
+++ b/lib/grape/rails/cache.rb
@@ -10,57 +10,38 @@ module Grape
         formatter :json, Grape::Rails::Cache::JsonFormatter
 
         helpers do
-          def compare_etag(etag)
-            etag = Digest::SHA1.hexdigest(etag.to_s)
-            error!("Not Modified", 304) if request.headers["If-None-Match"] == etag
-
-            header "ETag", etag
+          def set_headers(expiration_time, stale_time)
+            header "Cache-Control", "no-cache, no-store, must-revalidate"
+            header "Surrogate-Control", "max-age=#{expiration_time}, stale-if-error=#{stale_time}" if expiration_time > 0
           end
 
-          # Based on actionpack/lib/action_controller/base.rb, line 1216
-          def expires_in(seconds, options = {})
-            cache_control = []
-            if seconds == 0
-              cache_control << "no-cache"
-            else
-              cache_control << "max-age=#{seconds}"
-            end
-            if options[:public]
-              cache_control << "public"
-            else
-              cache_control << "private"
-            end
-
-            # This allows for additional headers to be passed through like 'max-stale' => 5.hours
-            cache_control += options.symbolize_keys.reject{|k,v| k == :public || k == :private }.map{ |k,v| v == true ? k.to_s : "#{k.to_s}=#{v.to_s}"}
-
-            header "Cache-Control", cache_control.join(', ')
+          def default_stale_if_error_time
+            24.hours
           end
 
           def default_expire_time
             2.hours
           end
 
+          # Usage:
+          #
+          #   cache(key: "your_cache_key", expires_in: 20.minutes, stale_for: 3.hours) do
+          #     SomeExpensiveMethod.new
+          #     render "index"
+          #   end
           def cache(opts = {}, &block)
-            # HTTP Cache
+            expiration_time = (opts[:expires_in] || default_expire_time).to_i
+            stale_time = (opts[:stale_for] || default_stale_if_error_time).to_i
             cache_key = opts[:key]
 
-            # Set Cache-Control
-            expires_in(opts[:expires_in] || default_expire_time, public: opts.fetch(:public, true) )
+            set_headers(expiration_time, stale_time)
 
-            if opts[:etag]
-              cache_key += ActiveSupport::Cache.expand_cache_key(opts[:etag])
-              compare_etag(opts[:etag]) # Check if client has fresh version
-            end
-
-            # Try to fetch from server side cache
-            cache_store_expire_time = (opts[:cache_store_expires_in] || opts[:expires_in] || default_expire_time).to_i
-            if cache_store_expire_time <= 0
-              block.call.to_json
-            else
-              ::Rails.cache.fetch(cache_key, raw: true, expires_in: cache_store_expire_time) do
+            if expiration_time > 0
+              ::Rails.cache.fetch(cache_key, raw: true, expires_in: expiration_time) do
                 block.call.to_json
               end
+            else
+              block.call.to_json
             end
           end
         end


### PR DESCRIPTION
We don't need the `cache-control` header to be dynamically set. Instead we need to use the `surrogate-control` header using this technique: https://docs.fastly.com/guides/tutorials/cache-control-tutorial
